### PR TITLE
Fix smithery build config and bundle OpenAPI spec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:22-slim AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY . ./
+RUN npm run build
+CMD ["node", "bin/cli.mjs"]

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "bin",
     "dist",
     "src",
+    "scripts/openapi.json",
     "README.md"
   ],
   "engines": {

--- a/scripts/start-server.ts
+++ b/scripts/start-server.ts
@@ -3,6 +3,7 @@ import axios from "axios";
 import yaml from "js-yaml";
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { OpenAPIV3 } from "openapi-types";
 import { AppKeyGenerator } from "../src/auth/get-key";
 import { MCPProxy } from "../src/mcp/proxy";
@@ -20,7 +21,7 @@ function isYamlFile(filePath: string): boolean {
 
 export async function loadOpenApiSpec(specPath?: string): Promise<OpenAPIV3.Document> {
   let rawSpec: string;
-  const defaultSpecPath = "http://localhost:31009/docs/openapi.yaml";
+  const defaultSpecPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "openapi.json");
   const finalSpecPath = specPath || defaultSpecPath;
 
   // Check if the path is a URL

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,5 @@
+version: 1
+builds:
+  default:
+    context: .
+    dockerfile: Dockerfile


### PR DESCRIPTION
## Summary
- include `scripts/openapi.json` in npm package
- bundle openapi spec from local file to avoid runtime dependency
- add smithery config and Dockerfile for smithery.ai

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*