### PR TITLE
Improve MCP tool safety metadata and error signaling

### DIFF
--- a/src/mcp/__tests__/proxy.test.ts
+++ b/src/mcp/__tests__/proxy.test.ts
@@ -2,7 +2,7 @@ import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { Headers } from "node-fetch";
 import { OpenAPIV3 } from "openapi-types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { HttpClient } from "../../client/http-client";
+import { HttpClient, HttpClientError } from "../../client/http-client";
 import { MCPProxy } from "../proxy";
 
 // Mock the dependencies
@@ -19,6 +19,9 @@ describe("MCPProxy", () => {
       .flatMap((x: unknown[]) => x)
       .filter((x: unknown) => typeof x === "function");
   };
+
+  const createHttpClientError = (status: number, data: unknown): HttpClientError =>
+    Object.assign(Object.create(HttpClientError.prototype), { status, data });
 
   const createMockOpenApiSpec = (overrides?: Partial<OpenAPIV3.Document>): OpenAPIV3.Document => ({
     openapi: "3.0.0",
@@ -67,6 +70,47 @@ describe("MCPProxy", () => {
 
       expect(result.tools[0].name.length).toBeLessThanOrEqual(64);
     });
+
+    it("should expose conservative annotations derived from HTTP methods", async () => {
+      const annotatedProxy = new MCPProxy(
+        "test-proxy",
+        createMockOpenApiSpec({
+          paths: {
+            "/resources": {
+              get: { operationId: "listResources", responses: { "200": { description: "Success" } } },
+              post: { operationId: "createResource", responses: { "201": { description: "Created" } } },
+              patch: { operationId: "patchResource", responses: { "200": { description: "Updated" } } },
+              put: { operationId: "replaceResource", responses: { "200": { description: "Replaced" } } },
+              delete: { operationId: "deleteResource", responses: { "204": { description: "Deleted" } } },
+            },
+          },
+        }),
+      );
+      const [listToolsHandler] = getHandlers(annotatedProxy);
+      const result = await listToolsHandler();
+      const annotations = Object.fromEntries(result.tools.map((tool: any) => [tool.name, tool.annotations]));
+
+      expect(annotations["API-listResources"]).toEqual({
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      });
+      expect(annotations["API-createResource"]).toEqual({
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      });
+      expect(annotations["API-patchResource"]).toEqual(annotations["API-createResource"]);
+      expect(annotations["API-replaceResource"]).toEqual({
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      });
+      expect(annotations["API-deleteResource"]).toEqual(annotations["API-replaceResource"]);
+    });
   });
 
   describe("callTool handler", () => {
@@ -102,6 +146,50 @@ describe("MCPProxy", () => {
       await expect(callToolHandler({ params: { name: "nonExistentMethod", arguments: {} } })).rejects.toThrow(
         "Method nonExistentMethod not found",
       );
+    });
+
+    it("should mark HTTP failures as MCP errors and preserve Anytype error details", async () => {
+      (HttpClient.prototype.executeOperation as ReturnType<typeof vi.fn>).mockRejectedValue(
+        createHttpClientError(500, {
+          status: 418,
+          object: "error",
+          code: "internal_server_error",
+          message: "failed to create block",
+        }),
+      );
+
+      const [, callToolHandler] = getHandlers(proxy);
+      const result = await callToolHandler({ params: { name: "API-getTest", arguments: {} } });
+
+      expect(result).toEqual({
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              status: 418,
+              object: "error",
+              code: "internal_server_error",
+              message: "failed to create block",
+              http_status: 500,
+            }),
+          },
+        ],
+      });
+    });
+
+    it("should include the HTTP status when an error response is not structured", async () => {
+      (HttpClient.prototype.executeOperation as ReturnType<typeof vi.fn>).mockRejectedValue(
+        createHttpClientError(502, "upstream unavailable"),
+      );
+
+      const [, callToolHandler] = getHandlers(proxy);
+      const result = await callToolHandler({ params: { name: "API-getTest", arguments: {} } });
+
+      expect(result).toEqual({
+        isError: true,
+        content: [{ type: "text", text: JSON.stringify({ data: "upstream unavailable", status: 502 }) }],
+      });
     });
 
     it("should handle tool names exceeding 64 characters", async () => {

--- a/src/mcp/proxy.ts
+++ b/src/mcp/proxy.ts
@@ -22,6 +22,7 @@ type NewToolDefinition = {
     description: string;
     inputSchema: IJsonSchema & { type: "object" };
     outputSchema?: IJsonSchema;
+    annotations: NonNullable<Tool["annotations"]>;
   }>;
 };
 
@@ -65,6 +66,7 @@ export class MCPProxy {
             name: truncatedToolName,
             description: method.description,
             inputSchema: method.inputSchema as Tool["inputSchema"],
+            annotations: method.annotations,
           });
         });
       });
@@ -102,14 +104,23 @@ export class MCPProxy {
         if (error instanceof HttpClientError) {
           console.error("HttpClientError encountered, returning structured error", error);
           const data = error.data?.response?.data ?? error.data ?? {};
+          const structuredData =
+            typeof data === "object" && data !== null && !Array.isArray(data)
+              ? {
+                  ...data,
+                  ...(data.status === undefined
+                    ? { status: error.status }
+                    : data.status === error.status
+                      ? {}
+                      : { http_status: error.status }),
+                }
+              : { data, status: error.status };
           return {
+            isError: true,
             content: [
               {
                 type: "text",
-                text: JSON.stringify({
-                  status: "error", // TODO: get this from http status code?
-                  ...(typeof data === "object" ? data : { data: data }),
-                }),
+                text: JSON.stringify(structuredData),
               },
             ],
           };

--- a/src/openapi/parser.ts
+++ b/src/openapi/parser.ts
@@ -1,4 +1,5 @@
 import type { Tool } from "@anthropic-ai/sdk/resources/messages/messages";
+import type { Tool as MCPTool } from "@modelcontextprotocol/sdk/types.js";
 import type { JSONSchema7 as IJsonSchema } from "json-schema";
 import type { ChatCompletionTool } from "openai/resources/chat/completions";
 import type { OpenAPIV3, OpenAPIV3_1 } from "openapi-types";
@@ -8,6 +9,7 @@ type NewToolMethod = {
   description: string;
   inputSchema: IJsonSchema & { type: "object" };
   outputSchema?: IJsonSchema;
+  annotations: NonNullable<MCPTool["annotations"]>;
 };
 
 type FunctionParameters = {
@@ -654,6 +656,7 @@ export class OpenAPIToMCPConverter {
         name: methodName,
         description,
         inputSchema,
+        annotations: this.getToolAnnotations(method),
         ...(outputSchema ? { outputSchema } : {}),
       };
     } catch (error) {
@@ -663,8 +666,27 @@ export class OpenAPIToMCPConverter {
         name: methodName,
         description,
         inputSchema,
+        annotations: this.getToolAnnotations(method),
         ...(outputSchema ? { outputSchema } : {}),
       };
+    }
+  }
+
+  private getToolAnnotations(method: string): NewToolMethod["annotations"] {
+    // This proxy only operates on the configured Anytype API, so its domain is
+    // closed. For mutations, HTTP verbs are safer signals than operation names:
+    // arbitrary POST/PATCH/PUT endpoints may replace or remove existing state.
+    switch (method.toLowerCase()) {
+      case "get":
+        return { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false };
+      case "delete":
+        return { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false };
+      case "put":
+        return { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false };
+      case "post":
+      case "patch":
+      default:
+        return { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false };
     }
   }
 


### PR DESCRIPTION
## Summary

- Mark HTTP failures as MCP errors with `isError: true` so clients do not treat failed mutations as successful tool calls.
- Preserve structured Anytype error fields and distinguish a conflicting HTTP transport status as `http_status`.
- Add conservative MCP tool annotations derived from HTTP methods, including read-only, destructive, idempotent, and closed-world hints.

This improves agent behavior around failed writes and gives MCP clients explicit safety metadata without changing the generated Anytype API surface.

Related to #107, #108, and #63.

## Testing

- `npm run lint`
- `npm run typecheck`
- `npm test` — 9 files, 90 tests passed
- `npm run build`
- `git diff --check origin/main...HEAD`
- Codex review — no accepted/actionable findings
