### PR TITLE
MCP | Feature | Add batch_get_objects tool for multi-ID retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Here are some examples of how you can interact with your Anytype:
 - "Add a new object of type 'Task' with title 'Research AI trends' to the 'Project Ideas' space"
 - "Create a second one with title 'Dive deep into LLMs' with due date in 3 days and assign it to me"
 - "Now create a collection with the title "Tasks for this week" and add the two tasks to that list. Set due date of the first one to 10 days from now"
+- "Fetch the latest details of the tasks with IDs 'task-1', 'task-2', and 'task-3' in one go"
 
 ## Development
 

--- a/src/mcp/__tests__/custom-tools.test.ts
+++ b/src/mcp/__tests__/custom-tools.test.ts
@@ -1,0 +1,156 @@
+import { OpenAPIV3 } from "openapi-types";
+import { describe, expect, it, vi } from "vitest";
+import { HttpClient, HttpClientError } from "../../client/http-client";
+import { batchGetObjectsSchema, runBatchGetObjects } from "../custom-tools";
+
+function createOpenApiLookup(): Record<string, OpenAPIV3.OperationObject & { method: string; path: string }> {
+  return {
+    "API-get-object": {
+      operationId: "get_object",
+      method: "get",
+      path: "/v1/spaces/{space_id}/objects/{object_id}",
+      parameters: [
+        { name: "space_id", in: "path", required: true, schema: { type: "string" } },
+        { name: "object_id", in: "path", required: true, schema: { type: "string" } },
+      ],
+      responses: { "200": { description: "The retrieved object" } },
+    },
+  };
+}
+
+function createHttpClientMock() {
+  const executeOperation = vi.fn();
+  const httpClient = {
+    executeOperation,
+  } as unknown as HttpClient;
+  return { httpClient, executeOperation };
+}
+
+function fulfilledObject(objectId: string) {
+  return { data: { id: objectId, name: `object-${objectId}` }, status: 200, headers: {} };
+}
+
+function rejected404(objectId: string) {
+  return Promise.reject(new HttpClientError("Not Found", 404, { error: "object not found" }));
+}
+
+function rejectedNetwork(objectId: string) {
+  return Promise.reject(new Error(`network error for ${objectId}`));
+}
+
+describe("batchGetObjectsSchema", () => {
+  it("accepts a valid input", () => {
+    const result = batchGetObjectsSchema.parse({
+      space_id: "space-1",
+      object_ids: ["a", "b"],
+    });
+    expect(result).toEqual({ space_id: "space-1", object_ids: ["a", "b"], concurrency: 5 });
+  });
+
+  it("defaults concurrency to 5", () => {
+    const result = batchGetObjectsSchema.parse({ space_id: "s", object_ids: ["a"] });
+    expect(result.concurrency).toBe(5);
+  });
+
+  it("rejects empty object_ids", () => {
+    expect(() => batchGetObjectsSchema.parse({ space_id: "s", object_ids: [] })).toThrow();
+  });
+
+  it("rejects more than 100 object IDs", () => {
+    const ids = Array.from({ length: 101 }, (_, i) => `id-${i}`);
+    expect(() => batchGetObjectsSchema.parse({ space_id: "s", object_ids: ids })).toThrow();
+  });
+});
+
+describe("runBatchGetObjects", () => {
+  it("returns found objects for all requested IDs", async () => {
+    const { httpClient, executeOperation } = createHttpClientMock();
+    executeOperation.mockResolvedValue(fulfilledObject("a"));
+
+    const result = await runBatchGetObjects(httpClient, createOpenApiLookup(), {
+      space_id: "space-1",
+      object_ids: ["a"],
+    });
+
+    expect(result.found).toEqual([{ id: "a", name: "object-a" }]);
+    expect(result.missing).toEqual([]);
+    expect(result.failed).toEqual([]);
+  });
+
+  it("reports missing (404) and failed IDs separately while keeping found objects", async () => {
+    const { httpClient, executeOperation } = createHttpClientMock();
+    executeOperation.mockImplementation((_op: unknown, params: { object_id: string }) => {
+      if (params.object_id === "missing") return rejected404(params.object_id);
+      if (params.object_id === "error") return rejectedNetwork(params.object_id);
+      return fulfilledObject(params.object_id);
+    });
+
+    const result = await runBatchGetObjects(httpClient, createOpenApiLookup(), {
+      space_id: "space-1",
+      object_ids: ["found", "missing", "error"],
+    });
+
+    expect(result.found).toEqual([{ id: "found", name: "object-found" }]);
+    expect(result.missing).toEqual(["missing"]);
+    expect(result.failed).toEqual([{ id: "error", error: "network error for error" }]);
+  });
+
+  it("fans out a separate get_object call per ID", async () => {
+    const { httpClient, executeOperation } = createHttpClientMock();
+    executeOperation.mockResolvedValue(fulfilledObject("a"));
+
+    await runBatchGetObjects(httpClient, createOpenApiLookup(), {
+      space_id: "space-1",
+      object_ids: ["a", "b", "c"],
+    });
+
+    expect(executeOperation).toHaveBeenCalledTimes(3);
+    expect(executeOperation).toHaveBeenNthCalledWith(1, expect.anything(), {
+      space_id: "space-1",
+      object_id: "a",
+    });
+    expect(executeOperation).toHaveBeenNthCalledWith(2, expect.anything(), {
+      space_id: "space-1",
+      object_id: "b",
+    });
+    expect(executeOperation).toHaveBeenNthCalledWith(3, expect.anything(), {
+      space_id: "space-1",
+      object_id: "c",
+    });
+  });
+
+  it("respects the concurrency limit when batching", async () => {
+    const { httpClient, executeOperation } = createHttpClientMock();
+    executeOperation.mockResolvedValue(fulfilledObject("a"));
+
+    const ids = ["1", "2", "3", "4", "5", "6"];
+    await runBatchGetObjects(httpClient, createOpenApiLookup(), {
+      space_id: "space-1",
+      object_ids: ids,
+      concurrency: 2,
+    });
+
+    expect(executeOperation).toHaveBeenCalledTimes(6);
+  });
+
+  it("deduplicates repeated object IDs", async () => {
+    const { httpClient, executeOperation } = createHttpClientMock();
+    executeOperation.mockResolvedValue(fulfilledObject("a"));
+
+    const result = await runBatchGetObjects(httpClient, createOpenApiLookup(), {
+      space_id: "space-1",
+      object_ids: ["a", "a", "b", "b"],
+    });
+
+    expect(executeOperation).toHaveBeenCalledTimes(2);
+    expect(result.found).toHaveLength(2);
+  });
+
+  it("throws when the get_object operation is missing from the spec", async () => {
+    const { httpClient } = createHttpClientMock();
+
+    await expect(runBatchGetObjects(httpClient, {}, { space_id: "space-1", object_ids: ["a"] })).rejects.toThrow(
+      "API-get-object",
+    );
+  });
+});

--- a/src/mcp/__tests__/proxy.test.ts
+++ b/src/mcp/__tests__/proxy.test.ts
@@ -233,4 +233,44 @@ describe("MCPProxy", () => {
       expect(server.connect).toHaveBeenCalledWith(mockTransport);
     });
   });
+
+  describe("custom tool: batch_get_objects", () => {
+    it("is exposed via tools/list", async () => {
+      const [listToolsHandler] = getHandlers(proxy);
+      const result = await listToolsHandler();
+      const names = result.tools.map((t: { name: string }) => t.name);
+
+      expect(names).toContain("batch_get_objects");
+    });
+
+    it("fans out get_object calls and aggregates the result", async () => {
+      (HttpClient.prototype.executeOperation as ReturnType<typeof vi.fn>).mockImplementation(
+        (_op: unknown, params: { object_id: string }) => {
+          if (params.object_id === "missing") {
+            return Promise.reject({ status: 404, message: "Not Found" });
+          }
+          return Promise.resolve({ data: { id: params.object_id }, status: 200, headers: new Headers() });
+        },
+      );
+
+      (proxy as any).openApiLookup = {
+        "API-get-object": {
+          operationId: "get_object",
+          method: "get",
+          path: "/v1/spaces/{space_id}/objects/{object_id}",
+          responses: { "200": { description: "The retrieved object" } },
+        },
+      };
+
+      const [, callToolHandler] = getHandlers(proxy);
+      const result = await callToolHandler({
+        params: { name: "batch_get_objects", arguments: { space_id: "space-1", object_ids: ["found", "missing"] } },
+      });
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.found).toEqual([{ id: "found" }]);
+      expect(parsed.missing).toEqual(["missing"]);
+      expect(parsed.failed).toEqual([]);
+    });
+  });
 });

--- a/src/mcp/custom-tools.ts
+++ b/src/mcp/custom-tools.ts
@@ -1,0 +1,132 @@
+import type { JSONSchema7 as IJsonSchema } from "json-schema";
+import { OpenAPIV3 } from "openapi-types";
+import { z } from "zod";
+import { HttpClient, HttpClientError } from "../client/http-client";
+
+/**
+ * Name of the tool that fetches several objects by ID in a single call.
+ *
+ * The upstream Anytype API has no native batch endpoint yet (see
+ * anyproto/anytype-api#36), so this tool fans out parallel `get_object`
+ * requests and aggregates the results while tolerating partial failures.
+ */
+export const BATCH_GET_OBJECTS_TOOL_NAME = "batch_get_objects";
+
+/**
+ * Zod schema for the `batch_get_objects` input. Zod is the source of truth for
+ * runtime validation; the matching JSON Schema exposed to the MCP client is
+ * derived from it below so LLM function calling stays descriptive.
+ */
+export const batchGetObjectsSchema = z.object({
+  space_id: z.string().min(1).describe("The ID of the space the objects belong to."),
+  object_ids: z
+    .array(z.string().min(1))
+    .min(1, "At least one object ID is required")
+    .max(100, "No more than 100 object IDs per call")
+    .describe(
+      "List of object IDs to fetch. Objects that do not exist or return an error " +
+        "are reported individually instead of failing the whole request.",
+    ),
+  concurrency: z
+    .number()
+    .int()
+    .min(1)
+    .max(20)
+    .default(5)
+    .describe("Maximum number of objects to fetch in parallel. Defaults to 5."),
+});
+
+export type BatchGetObjectsInput = z.infer<typeof batchGetObjectsSchema>;
+
+/**
+ * JSON Schema descriptor used by the MCP `tools/list` response. Kept in sync
+ * with `batchGetObjectsSchema` while staying consistent with the plain
+ * JSON-Schema style the rest of the server uses for generated tools.
+ */
+export const batchGetObjectsInputSchema: IJsonSchema & { type: "object" } = {
+  type: "object",
+  properties: {
+    space_id: {
+      type: "string",
+      description: "The ID of the space the objects belong to.",
+    },
+    object_ids: {
+      type: "array",
+      items: { type: "string" },
+      minItems: 1,
+      maxItems: 100,
+      description:
+        "List of object IDs to fetch. Objects that do not exist or return an error are reported individually instead of failing the whole call.",
+    },
+    concurrency: {
+      type: "number",
+      minimum: 1,
+      maximum: 20,
+      default: 5,
+      description: "Maximum number of objects to fetch in parallel. Defaults to 5.",
+    },
+  },
+  required: ["space_id", "object_ids"],
+};
+
+/** The operation the batch tool fans out to (generated from the OpenAPI spec). */
+const GET_OBJECT_OPERATION_KEY = "API-get-object";
+
+function isMissingObjectError(error: unknown): boolean {
+  const status = error instanceof HttpClientError ? error.status : (error as { status?: number } | undefined)?.status;
+  return status === 404;
+}
+
+/**
+ * Fetch multiple objects by ID with partial-failure handling.
+ *
+ * @returns A structured result containing successfully fetched objects, the IDs
+ *   that were not found (HTTP 404) and the IDs whose fetch failed for any other
+ *   reason. Never throws for per-object failures.
+ */
+export async function runBatchGetObjects(
+  httpClient: HttpClient,
+  openApiLookup: Record<string, OpenAPIV3.OperationObject & { method: string; path: string }>,
+  rawInput: unknown,
+): Promise<BatchGetObjectsResult> {
+  const input = batchGetObjectsSchema.parse(rawInput);
+  const getObjectOperation = openApiLookup[GET_OBJECT_OPERATION_KEY];
+  if (!getObjectOperation) {
+    throw new Error(`Operation "${GET_OBJECT_OPERATION_KEY}" not found in the OpenAPI spec`);
+  }
+
+  // Preserve input order and avoid duplicate IDs causing needless requests.
+  const objectIds = [...new Set(input.object_ids)];
+  const { space_id, concurrency } = input;
+
+  const found: unknown[] = [];
+  const missing: string[] = [];
+  const failed: Array<{ id: string; error: string }> = [];
+
+  for (let offset = 0; offset < objectIds.length; offset += concurrency) {
+    const chunk = objectIds.slice(offset, offset + concurrency);
+    const settled = await Promise.allSettled(
+      chunk.map((object_id) => httpClient.executeOperation(getObjectOperation, { space_id, object_id })),
+    );
+
+    settled.forEach((result, index) => {
+      const id = chunk[index];
+      if (result.status === "fulfilled") {
+        found.push(result.value.data);
+      } else if (isMissingObjectError(result.reason)) {
+        missing.push(id);
+      } else {
+        const reason = result.reason as { message?: string } | undefined;
+        failed.push({ id, error: reason?.message ?? String(result.reason) });
+      }
+    });
+  }
+
+  return { found, missing, failed };
+}
+
+export type BatchGetObjectsResult = {
+  found: unknown[];
+  missing: string[];
+  failed: Array<{ id: string; error: string }>;
+};

--- a/src/mcp/proxy.ts
+++ b/src/mcp/proxy.ts
@@ -4,9 +4,11 @@ import { CallToolRequestSchema, ListToolsRequestSchema, Tool } from "@modelconte
 import { JSONSchema7 as IJsonSchema } from "json-schema";
 import { Headers } from "node-fetch";
 import { OpenAPIV3 } from "openapi-types";
+import { ZodError } from "zod";
 import { HttpClient, HttpClientError } from "../client/http-client";
 import { OpenAPIToMCPConverter } from "../openapi/parser";
 import { determineBaseUrl } from "../utils/base-url";
+import { BATCH_GET_OBJECTS_TOOL_NAME, batchGetObjectsInputSchema, runBatchGetObjects } from "./custom-tools";
 
 type PathItemObject = OpenAPIV3.PathItemObject & {
   get?: OpenAPIV3.OperationObject;
@@ -69,6 +71,15 @@ export class MCPProxy {
         });
       });
 
+      // Add custom tools that are not derived from the OpenAPI spec
+      tools.push({
+        name: BATCH_GET_OBJECTS_TOOL_NAME,
+        description:
+          "Fetch multiple objects by ID in a single call. Returns successfully fetched objects " +
+          "alongside the IDs that could not be retrieved instead of failing the whole request.",
+        inputSchema: batchGetObjectsInputSchema as Tool["inputSchema"],
+      });
+
       return { tools };
     });
 
@@ -76,6 +87,26 @@ export class MCPProxy {
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
       console.error("calling tool", request.params);
       const { name, arguments: params } = request.params;
+
+      // Route custom tools before falling back to the OpenAPI-generated ones
+      if (name === BATCH_GET_OBJECTS_TOOL_NAME) {
+        try {
+          const result = await runBatchGetObjects(this.httpClient, this.openApiLookup, params);
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(result),
+              },
+            ],
+          };
+        } catch (error) {
+          if (error instanceof ZodError) {
+            throw new Error(`Invalid arguments for ${BATCH_GET_OBJECTS_TOOL_NAME}: ${error.message}`, { cause: error });
+          }
+          throw error;
+        }
+      }
 
       // Find the operation in OpenAPI spec
       const operation = this.findOperation(name);


### PR DESCRIPTION
MCP tool for https://github.com/anyproto/anytype-api/issues/36

  Adds a batch_get_objects tool that fetches multiple objects by ID in a single MCP call via bounded-concurrency fan-out over get_object.

### Description

This PR adds a new `batch_get_objects` MCP tool that retrieves multiple objects by their IDs within a space in one call. The tool fans out to the existing `get_object` operation with configurable concurrency and aggregates results into `{ found, missing, failed }`, so a single missing or failing ID never fails the whole call.

**Changes:**
- Added `src/mcp/custom-tools.ts` with the tool definition and handler (Zod + JSON Schema for MCP `tools/list`)
- Schema: `space_id`, `object_ids` (1-100), `concurrency` (default 5, max 20)
- Deduplicates IDs, chunks by concurrency, uses `Promise.allSettled`
- Treats 404 as `missing`; other errors surface in `failed` with the message
- Wired into `src/mcp/proxy.ts` (listed and routed before the OpenAPI fallback; parse errors wrapped with `cause`)
- Added 10 unit tests in `custom-tools.test.ts` + integration coverage in `proxy.test.ts`
- Added README example usage line

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents

- Feature request: https://github.com/anyproto/anytype-api/issues/36
- Companion OpenAPI spec proposal: https://github.com/anyproto/anytype-api/pull/98

### Mobile & Desktop Screenshots/Recordings

N/A.

**Example response (real Anytype space: 3 real IDs + 2 bogus IDs):**
```json
{
  "found": [
    { "object": { "id": "bafyreigufbb...", "name": "Day 4 Upper Hypertrophy", "layout": "basic", ... } },
    { "object": { "id": "bafyreigk3...", "name": "Day 2 Lower Strength", "layout": "basic", ... } },
    { "object": { "id": "bafyreidsd...", "name": "Day 5 Lower Hypertrophy", "layout": "basic", ... } }
  ],
  "missing": [],
  "failed": [
    { "id": "bogus-missing-id-1", "error": "500 Internal Server Error" },
    { "id": "bogus-missing-id-2", "error": "500 Internal Server Error" }
  ]
}
```

**Verification:**
- `bun run typecheck` passes
- `bun run lint` passes
- `bun run test` (vitest): 99 tests passing
- `bun run build` passes
- E2E via stdio JSON-RPC against local Anytype Desktop (API at 127.0.0.1:31009): tool listed, fan-out works, partial failures isolated